### PR TITLE
fix(he): repair broken hero image on Hebrew dashboard post

### DIFF
--- a/he/posts/toffu-is-a-teammate-not-a-dashboard-builder.md
+++ b/he/posts/toffu-is-a-teammate-not-a-dashboard-builder.md
@@ -2,7 +2,7 @@
 title: "אתם לא צריכים דשבורד. אתם צריכים תשובה."
 description: "למה דשבורדים הפכו למיותרים ברגע שיש לכם שותף AI בצוות, ואיך להוציא יותר מ-Toffu על ידי בקשת תשובות במקום ממשקים."
 date: "2026-04-23"
-image: "https://i.toffu.ai/toffu-teammate-not-dashboard-hero_bg1efisw.png"
+image: "https://raw.githubusercontent.com/toffu-ai/blog-posts/main/images/you-dont-need-a-dashboard-you-need-an-answer-hero.png"
 slug: "toffu-is-a-teammate-not-a-dashboard-builder"
 lang: "he"
 dir: "rtl"


### PR DESCRIPTION
## Summary
- The Hebrew translation of the "You Don't Need a Dashboard" post still pointed at the dead \`i.toffu.ai\` CDN URL
- PR #6 fixed the English post but missed the \`he/\` counterpart, so toffu.ai/he/blog renders a broken image card
- Point the Hebrew frontmatter at the same GitHub-hosted hero the English version now uses

## Test plan
- [ ] Confirm toffu.ai/he/blog renders the hero card with the image after deploy
- [ ] Verify the image URL returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)