### PR TITLE
content: link Claude MCP mention to the Toffu MCP setup page

### DIFF
--- a/posts/best-ai-marketing-tools.md
+++ b/posts/best-ai-marketing-tools.md
@@ -64,7 +64,7 @@ Where Claude stands out vs. ChatGPT: better at following complex multi-step inst
 
 **Pricing:** Free tier available. Claude Pro at $20/month. Team plans available. [claude.ai](https://claude.ai)
 
-**Limitation:** No native tool integrations. To connect Claude to your marketing stack, you need an agent layer like Toffu or build your own MCP setup.
+**Limitation:** No native tool integrations. To connect Claude to your marketing stack, you need an agent layer like Toffu or build your own MCP setup. The fastest route is [connecting Claude to Toffu over MCP](https://toffu.ai/academy/mcp) — one OAuth click, and Claude can pull campaign performance and creative reports from your ad accounts.
 
 #### 3. Surfer SEO
 


### PR DESCRIPTION
`best-ai-marketing-tools` already names Claude's MCP support in the limitations line but dead-ends there. Adds one in-body link to https://toffu.ai/academy/mcp with the concrete payoff (OAuth once, Claude reads campaign performance and creative reports).

Paired with toffu-ai/toffu-chat#740, which un-orphans that page — it currently has almost no inbound internal links, which is why it is indexed but ranks for nothing. This is a real editorial link from a topically-matched post, not a footer dump.